### PR TITLE
lock chef-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Following options are available.
 
 * Settings for chef and paratrooper
 
-    * `:chef_version` - chef version. empty by default. use latest version by default.
+    * `:chef_version` - chef version. `latest` by default.
     * `:chef_environment` - environment setting. empty by default.
     * `:chef_roles_auto_discovery` - Enable "Chef roles Auto discovery". use `false` by default.
     * `:chef_verbose_logging`, - Enable verbose logging mode of `chef-solo`. use `true` by default.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Following options are available.
 
 * Settings for chef and paratrooper
 
+    * `:chef_version` - chef version. empty by default. use latest version by default.
     * `:chef_environment` - environment setting. empty by default.
     * `:chef_roles_auto_discovery` - Enable "Chef roles Auto discovery". use `false` by default.
     * `:chef_verbose_logging`, - Enable verbose logging mode of `chef-solo`. use `true` by default.

--- a/lib/capistrano-paratrooper-chef/omnibus_install.rb
+++ b/lib/capistrano-paratrooper-chef/omnibus_install.rb
@@ -19,14 +19,14 @@ Capistrano::Configuration.instance.load do
   namespace :paratrooper do
     namespace :chef do
       set :chef_solo_path, "/opt/chef/bin/chef-solo"
-
+      set :chef_version, "latest"
+      
       desc "Installs chef (by omnibus installer)"
       task :install_omnibus_chef do
-        chef_version_option = exists?(:chef_version) ? " -s -- -v #{fetch(:chef_version)}" : ""
         if capture("command -v curl || true").strip.empty?
-          run "wget -O - http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash#{chef_version_option}"
+          run "wget -O - http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash -s -- -v #{fetch(:chef_version)}"
         else
-          run "curl -L http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash#{chef_version_option}"
+          run "curl -L http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash -s -- -v #{fetch(:chef_version)}"
         end
       end
       after "deploy:setup", "paratrooper:chef:install_omnibus_chef"

--- a/lib/capistrano-paratrooper-chef/omnibus_install.rb
+++ b/lib/capistrano-paratrooper-chef/omnibus_install.rb
@@ -22,10 +22,11 @@ Capistrano::Configuration.instance.load do
 
       desc "Installs chef (by omnibus installer)"
       task :install_omnibus_chef do
+        chef_version_option = fetch(:chef_version) ? " -s -- -v #{fetch(:chef_version)}" : ""
         if capture("command -v curl || true").strip.empty?
-          run "wget -O - http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash"
+          run "wget -O - http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash#{chef_version_option}"
         else
-          run "curl -L http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash"
+          run "curl -L http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash#{chef_version_option}"
         end
       end
       after "deploy:setup", "paratrooper:chef:install_omnibus_chef"

--- a/lib/capistrano-paratrooper-chef/omnibus_install.rb
+++ b/lib/capistrano-paratrooper-chef/omnibus_install.rb
@@ -22,7 +22,7 @@ Capistrano::Configuration.instance.load do
 
       desc "Installs chef (by omnibus installer)"
       task :install_omnibus_chef do
-        chef_version_option = fetch(:chef_version) ? " -s -- -v #{fetch(:chef_version)}" : ""
+        chef_version_option = exists?(:chef_version) ? " -s -- -v #{fetch(:chef_version)}" : ""
         if capture("command -v curl || true").strip.empty?
           run "wget -O - http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash#{chef_version_option}"
         else


### PR DESCRIPTION
#### 問題

Deploy: Ubuntu 12.04, Chef 12.5.1
App: Ubuntu 14.04, Chef 12.11.18
`500 "Internal Server Error"`のエラーが発生しました。
#### 解決

Deploy: Ubuntu 14.04, Chef 12.10.24にして、Chefが動けるようになりました。
#### アップデート内容

Chef version 古いで、Chef Versionを設定できるようにしたいです。

```
# deploy.rb
set :chef_version, "12.10.24"
```

の場合"12.10.24"のChefをインストールします。

```
# deploy.rb
# set :chef_version, "12.10.24"
```

の場合最新のChefをインストールします。
