### PR TITLE
fix permission error

### DIFF
--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -310,7 +310,8 @@ Capistrano::Configuration.instance.load do
       end
 
       def ensure_working_dir
-        run "rm -rf #{fetch(:chef_working_dir)} && mkdir -p #{fetch(:chef_working_dir)}"
+        sudo "rm -rf #{fetch(:chef_working_dir)}"
+        run "mkdir -p #{fetch(:chef_working_dir)}"
         sudo "mkdir -p #{fetch(:chef_cache_dir)}"
       end
 


### PR DESCRIPTION
#### 問題

Chefは`local-mode-cache/backup/etc/`のところでroot権限のファイルを生成しました。
`run "rm -rf #{fetch(:chef_working_dir)}`だとPermission Errorが出ました。
#### 解決

sudo権限で`run "rm -rf #{fetch(:chef_working_dir)}`を実行すると消せました。
