### PR TITLE
Add option chef_legacy_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Following options are available.
     * `:chef_roles_auto_discovery` - Enable "Chef roles Auto discovery". use `false` by default.
     * `:chef_verbose_logging`, - Enable verbose logging mode of `chef-solo`. use `true` by default.
     * `:chef_debug` - Enable debug mode of `chef-solo`. use `false` by default.
+    * `:chef_legacy_mode` - Enable legacy mode of `chef-solo`. use `false` by default. In Chef 12.11.18 or later is recommended `true`.
 
 * Settings for directories
 

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -45,6 +45,7 @@ Capistrano::Configuration.instance.load do
     }
 
     # chef settings
+    set :chef_legacy_mode, false
     set :chef_roles_auto_discovery, false
     set :chef_verbose_logging, true
     set :chef_debug, false
@@ -235,7 +236,7 @@ Capistrano::Configuration.instance.load do
       desc "Run chef-solo"
       task :execute do
         logger.info "Now running chef-solo"
-        command = "#{chef_solo_path} -c #{remote_path("solo.rb")} -j #{remote_path("solo.json")}#{' -l debug' if fetch(:chef_debug)}"
+        command = "#{chef_solo_path} -c #{remote_path("solo.rb")} -j #{remote_path("solo.json")}#{' --legacy-mode' if fetch(:chef_legacy_mode)}#{' -l debug' if fetch(:chef_debug)}"
         if run_list.unique?
           sudo command
         else
@@ -249,7 +250,7 @@ Capistrano::Configuration.instance.load do
       desc "why-run chef-solo"
       task :execute_why_run do
         logger.info "Now running why-run chef-solo"
-        command = "#{chef_solo_path} -c #{remote_path("solo.rb")} -j #{remote_path("solo.json")} -l fatal --why-run"
+        command = "#{chef_solo_path} -c #{remote_path("solo.rb")} -j #{remote_path("solo.json")}#{' --legacy-mode' if fetch(:chef_legacy_mode)} -l fatal --why-run"
         if run_list.unique?
           sudo command
         else


### PR DESCRIPTION
Chef 12.11.18以降、以下の変更によりchef-soloがlocal mode(chef-client -zと同等)を使うようになった。
https://github.com/chef/chef/blob/master/RELEASE_NOTES.md#replace-chef-solo-with-chef-client-local-mode
https://github.com/chef/chef/pull/4919
legacy-modeを使うと、local modeを使わずに済むので応急処置。
