### PR TITLE
Add chef_scp_max_concurrency option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Following options are available.
     * `:chef_solo_path` - the path of `chef-solo` command. use `chef-solo` by default (search command from $PATH).
     * `:chef_working_dir` - the path where chef-kitchen should installed. use `$HOME/chef-solo` by default.
     * `:chef_cache_dir` - the path for caches. use `/var/chef/cache` by default.
+    * `:chef_scp_max_concurrency` - the value for scp concurrency. use `100` by default.
 
 * Settings for chef and paratrooper
 

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -33,6 +33,7 @@ Capistrano::Configuration.instance.load do
     set :chef_environment_path, "environments"
     set :chef_databags_path, "data_bags"
     set :chef_databag_secret, "data_bag_key"
+    set :chef_scp_max_concurrency, 100
 
     # remote chef settings
     set :chef_solo_path, "chef-solo"
@@ -316,7 +317,7 @@ Capistrano::Configuration.instance.load do
       end
 
       desc "Upload files in kitchen"
-      task :upload do
+      task :upload, :max_hosts => fetch(:chef_scp_max_concurrency) do
         berkshelf.fetch
         librarian_chef.fetch
 


### PR DESCRIPTION
kitchen.tarをscpによってアップロードする際、瞬間的なメモリ消費量の節約のため、並列度を指定できるようにしました。
