### PR TITLE
Add option cookbooks manage tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Following options are available.
     * `:chef_verbose_logging`, - Enable verbose logging mode of `chef-solo`. use `true` by default.
     * `:chef_debug` - Enable debug mode of `chef-solo`. use `false` by default.
     * `:chef_legacy_mode` - Enable legacy mode of `chef-solo`. use `false` by default. In Chef 12.11.18 or later is recommended `true`.
+    * `:chef_download_cookbooks` - `true` is download cookbooks by librarian-chef/Berkshelf. false is no download. use `true` by default.
 
 * Settings for directories
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Following options are available.
     * `:chef_debug` - Enable debug mode of `chef-solo`. use `false` by default.
     * `:chef_legacy_mode` - Enable legacy mode of `chef-solo`. use `false` by default. In Chef 12.11.18 or later is recommended `true`.
     * `:chef_download_cookbooks` - `true` is download cookbooks by librarian-chef/Berkshelf. false is no download. use `true` by default.
+    * `:chef_cookbooks_manage_tool` - `:discover` or `:librarian_chef` or `:berkshelf`. default is `:discover`.
 
 * Settings for directories
 

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -34,6 +34,7 @@ Capistrano::Configuration.instance.load do
     set :chef_databags_path, "data_bags"
     set :chef_databag_secret, "data_bag_key"
     set :chef_scp_max_concurrency, 100
+    set :chef_download_cookbooks, true
 
     # remote chef settings
     set :chef_solo_path, "chef-solo"
@@ -318,8 +319,11 @@ Capistrano::Configuration.instance.load do
 
       desc "Upload files in kitchen"
       task :upload, :max_hosts => fetch(:chef_scp_max_concurrency) do
-        berkshelf.fetch
-        librarian_chef.fetch
+
+        if fetch(:chef_download_cookbooks)
+          berkshelf.fetch
+          librarian_chef.fetch
+        end
 
         stream = StringIO.new
         TarWriter.new(stream) do |writer|


### PR DESCRIPTION
https://github.com/monsterstrike/capistrano-paratrooper-chef/pull/9 を含んでます。

librarian-chef/Berkshel両方の定義ファイルが存在したとしても、
オプションにより設定されているものがあれば、強制的に選択して実行できるようにした。

デフォルトの挙動は変更されていません。
