### PR TITLE
fix deprecated plugin_path

### DIFF
--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -220,7 +220,7 @@ Capistrano::Configuration.instance.load do
           environment_path File.join(root, #{kitchen.environment_path.inspect})
           data_bag_path File.join(root, #{kitchen.databags_path.inspect})
           verbose_logging #{fetch(:chef_verbose_logging)}
-          Ohai::Config[:plugin_path] << '/opt/chef/plugins'
+          ohai.plugin_path << '/opt/chef/plugins'
         CONF
         if File.exist?(kitchen.databag_secret_path)
           config += <<-CONF


### PR DESCRIPTION
```
WARN: Ohai::Config[:plugin_path] is set. Ohai::Config[:plugin_path] is deprecated and will be removed in future releases of ohai. Use ohai.plugin_path in your configuration file to configure :plugin_path for ohai.
```
というwarningが出てしまう問題に対処。