### PR TITLE
paratrooper:chef:install_omnibus_chefをdeploy:setupのbefore hookに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To setup paratrooper-chef for your application, add following in you config/depl
     # in "config/deploy.rb"
     require 'capistrano-paratrooper-chef'
 
-And then, put your chef-kitchen files to config/ directory. 
+And then, put your chef-kitchen files to config/ directory.
 by default, paratrooper-chef uses following files and directories.
 
 * config/Berksfile
@@ -52,6 +52,7 @@ To enable it, add following in your config/deploy.rb.
     require "capistrano-paratrooper-chef/omnibus_install"
 
 This recipe will install chef-solo using omnibus-installer during deploy:setup task.
+Even in the case of no_release option is enable, will install chef-solo.
 
 Another way, you want to install chef-solo as gem package, use following lines.
 
@@ -126,7 +127,7 @@ Following options are available.
 * Settings for directories
 
     * `:chef_kitchen_path` - root directory of kitchen. use `config` by default.
-    * `:chef_default_solo_json_path` - default attribute file a.k.a solo.json. use `solo.json` by default. 
+    * `:chef_default_solo_json_path` - default attribute file a.k.a solo.json. use `solo.json` by default.
     * `:chef_cookbooks_path` - cookbooks directory (or list of directories). use `site-cookbooks` by default.
     * `:chef_vendor_cookbooks_path` - cookbooks directory for berkshelf/librarian. use `vendor/cookbooks` by default.
     * `:chef_nodes_path` - nodes directory. use `nodes` by default.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To enable it, add following in your config/deploy.rb.
     require "capistrano-paratrooper-chef/omnibus_install"
 
 This recipe will install chef-solo using omnibus-installer during deploy:setup task.
-Even in the case of no_release option is enable, will install chef-solo.
+Even in the case of no_release option is enable, will install chef-solo. (Only if you use `omnibus_install`)
 
 Another way, you want to install chef-solo as gem package, use following lines.
 

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -197,7 +197,6 @@ Capistrano::Configuration.instance.load do
       end
 
       task :before_execute do
-        chef.install_if_require
         run_list.discover
         run_list.ensure
         kitchen.ensure_cookbooks
@@ -205,12 +204,6 @@ Capistrano::Configuration.instance.load do
         kitchen.upload
         chef.generate_solo_rb
         chef.generate_solo_json
-      end
-
-      def install_if_require
-        run "which #{chef_solo_path}"
-      rescue
-        chef.install_omnibus_chef
       end
 
       task :solo do

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -197,6 +197,7 @@ Capistrano::Configuration.instance.load do
       end
 
       task :before_execute do
+        chef.install_if_require
         run_list.discover
         run_list.ensure
         kitchen.ensure_cookbooks
@@ -204,6 +205,12 @@ Capistrano::Configuration.instance.load do
         kitchen.upload
         chef.generate_solo_rb
         chef.generate_solo_json
+      end
+
+      def install_if_require
+        run "which #{chef_solo_path}"
+      rescue
+        chef.install_omnibus_chef
       end
 
       task :solo do

--- a/lib/capistrano-paratrooper-chef/omnibus_install.rb
+++ b/lib/capistrano-paratrooper-chef/omnibus_install.rb
@@ -20,7 +20,7 @@ Capistrano::Configuration.instance.load do
     namespace :chef do
       set :chef_solo_path, "/opt/chef/bin/chef-solo"
       set :chef_version, "latest"
-      
+
       desc "Installs chef (by omnibus installer)"
       task :install_omnibus_chef do
         if capture("command -v curl || true").strip.empty?
@@ -29,7 +29,7 @@ Capistrano::Configuration.instance.load do
           run "curl -L http://www.opscode.com/chef/install.sh | #{top.sudo if fetch(:chef_use_sudo)} bash -s -- -v #{fetch(:chef_version)}"
         end
       end
-      after "deploy:setup", "paratrooper:chef:install_omnibus_chef"
+      before "deploy:setup", "paratrooper:chef:install_omnibus_chef"
     end
   end
 end


### PR DESCRIPTION
`deploy:setup`はno_releaseが有効な場合、実行されません。
`paratrooper:chef:install_omnibus_chef` が `deploy:setup` のafter hookとして設定されているので、実行されずchef-soloはinstallされません。
アプリコードを撒くが、chefを当てるroleが存在するので、before hook に変更することにより、chef-soloは常にinstallされるように変更する