### PR TITLE
chef_working_dirを作り直す際もsudoする

### DIFF
--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -322,7 +322,7 @@ Capistrano::Configuration.instance.load do
       end
 
       def ensure_working_dir
-        run "rm -rf #{fetch(:chef_working_dir)} && mkdir -p #{fetch(:chef_working_dir)}"
+        sudo "rm -rf #{fetch(:chef_working_dir)} && mkdir -p #{fetch(:chef_working_dir)}"
         sudo "mkdir -p #{fetch(:chef_cache_dir)}"
       end
 

--- a/lib/capistrano-paratrooper-chef/chef.rb
+++ b/lib/capistrano-paratrooper-chef/chef.rb
@@ -322,7 +322,8 @@ Capistrano::Configuration.instance.load do
       end
 
       def ensure_working_dir
-        sudo "rm -rf #{fetch(:chef_working_dir)} && mkdir -p #{fetch(:chef_working_dir)}"
+        sudo "rm -rf #{fetch(:chef_working_dir)}"
+        run "mkdir -p #{fetch(:chef_working_dir)}"
         sudo "mkdir -p #{fetch(:chef_cache_dir)}"
       end
 


### PR DESCRIPTION
https://github.com/chef-cookbooks/chef_nginx/blob/master/recipes/ohai_plugin.rb#L29-L33
のようにohai_plugin resourceを使ってpluginをインストールする場合、
https://github.com/chef-cookbooks/ohai/blob/master/resources/plugin.rb#L32-L34
でインストール先のパスを組み立ててroot権限でファイルが作られる。

しかし、Chef::Config['config_file']がchefの実行ユーザが所属するディレクトリの場合、
`:chef_working_dir` 以下にohai_pluginディレクトリが作成され権限が混在する状況となってしまう。

例)
`Chef::Config['config_file']` および `:chef_working_dir` が /home/hoge/chef-solo の場合

ohai_pluginを使うと

/home/hoge/chef-solo/ohai/plugins/plugin_name.rb

といったファイルがroot権限で作成される。
/home/hoge/chef-soloまではhogeユーザーの権限だが、それ以下はroot権限。

この場合、sudoがないとPermission deniedとなりrmすることができない。